### PR TITLE
Fix reading of settings from tsconfig.json

### DIFF
--- a/atmosphere-packages/angular-typescript-compiler/index.js
+++ b/atmosphere-packages/angular-typescript-compiler/index.js
@@ -163,7 +163,7 @@ export class AngularTsCompiler {
               tsFilePaths.push(filePath);
               fullPaths.push(path.join(basePath, filePath));
             }
-          }else if(inputFile.getBasename() == 'tsconfig.json'){
+          }else if(inputFile.getBasename() == 'tsconfig.json' && !filePath.startsWith('node_modules')){
             tsConfig = JSON.parse(inputFile.getContentsAsString());
           }
           filesMap.set(filePath, index);


### PR DESCRIPTION
Condition was added for defining is tsconfig.json from project and not from node_modules, case when user install some package directly from github repository

Before you submit a pull request, please make sure you have to following:

- [ ] Your code should contain tests relevant for the problem you are solving
- [ ] All new and existing tests passed
- [ ] Your commits messages format follows the `angular` project [git commit message format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines)

### When updating the site
- [ ] A description of the problem you're trying to solve
- [ ] An overview of the suggested solution
- [ ] If the feature changes current behavior, reasons why your solution is better.



